### PR TITLE
Stop using forked maven action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -22,7 +22,7 @@ action "Login into Docker Hub" {
 }
 
 action "Maven clean install" {
-  uses = "pcraig3/action-maven-cli/jdk11@master"
+  uses = "xlui/action-maven-cli/jdk11@18bbe92f79e2aba73a7dab743c84638c85db321b"
   needs = ["If master branch"]
   args = "clean install"
 }


### PR DESCRIPTION
I forked a jdk11 maven action in order to get this to build properly, and then opened an upstream pull request against [the original repo](https://github.com/xlui/action-maven-cli).

[Since the PR was merged](https://github.com/xlui/action-maven-cli/pull/1), I can delete my fork.

Note that I switched from referencing the `master` branch to the current SHA so that new changes aren't automatically added to the workflow.