### PR TITLE
Hardcode date strings with current year

### DIFF
--- a/src/main/java/ca/pcraig3/holidays/holiday/Holiday.java
+++ b/src/main/java/ca/pcraig3/holidays/holiday/Holiday.java
@@ -75,9 +75,12 @@ public class Holiday {
 
     public String getDate() {
 
+        // without this, the API starts returning holidays for next year prematurely
+        String currentYear = " 2019";
+
         String _date = (this.date.equals("Monday on or before May 24")) ? "Monday before May 25" : this.date;
 
-        Date firstDate = str2Date(_date);
+        Date firstDate = str2Date(_date + currentYear);
         // iso format : "yyyy-MM-dd'T'HH:mm:ss.SSSZ" (ie, 2019-01-01T00:00:00.000)
         // spoken english format : "EEEE, MMMM d" (ie, Tuesday, January 1)
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.CANADA);


### PR DESCRIPTION
The way the API works, it takes a human readable date string from Wikipedia and then it interprets it into a Java Date. So with a string like "Third Wednesday of April", it will go ahead and convert that into a useable ISO date.

However, since there's no year information, it will just take a guess.
In our case, if the date had already passed for this year, it finds the date for next year.

Technically it works as expected, but since it's not what we want our API to do, it's a bug. Hardcoding the year to the end of the date string works for 100% of our holiday strings so that's probably fine until we need to make this more complicated.

Thanks to @sastels for his eagle-eyed vigilance. "Quis custodiet ipsos custodes?" indeed.